### PR TITLE
feat(keypair): Make `KeyFormat` more convenient

### DIFF
--- a/keypair/src/key_pair.rs
+++ b/keypair/src/key_pair.rs
@@ -48,7 +48,7 @@ use std::str::FromStr;
 /// ```
 ///
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyFormat {
     Ed25519,
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
1. Make `KeyFormat` clonable and comparable.
2. Add `KeyPair::key_format(&self) -> KeyFormat` method.