### PR TITLE
fix(trust-graph): Regenerate aqua bindings from wasm

### DIFF
--- a/service/build.sh
+++ b/service/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
+
 set -o errexit -o nounset -o pipefail
+set -x
 
 # set current working directory to script directory to run script from everywhere
 cd "$(dirname "$0")"


### PR DESCRIPTION
This PR is created just to trigger `marine` execution on release action to regenerate aqua bindings from service